### PR TITLE
Fix gc_time graph not displayed

### DIFF
--- a/elasticsearch_
+++ b/elasticsearch_
@@ -148,7 +148,7 @@ data['gc'] = {
 }
 
 data['gc_time'] = {
-    "count" => node_stats['jvm']['gc']['collectors'].inject(0) {|sum, collector| sum += collector.last['collection_time_in_millis']}
+    "time" => node_stats['jvm']['gc']['collectors'].inject(0) {|sum, collector| sum += collector.last['collection_time_in_millis']}
 }
 
 data['cache'] = {


### PR DESCRIPTION
Munin is not displaying  graphs in my servers. 
I noticed that `data['gc_time']['count']` is incorrect, maybe `data['gc_time']['time']` is correct.

Please confirm.
Thank you.
