### PR TITLE
Filter node when calling _nodes API

### DIFF
--- a/elasticsearch_
+++ b/elasticsearch_
@@ -120,9 +120,9 @@ end
 data = {};
 
 begin
-    nodes_d = fetch('/_nodes');
     node_encode = URI.escape(@node)
-    stats_d = fetch( '/_nodes/'+node_encode+'/stats');
+    nodes_d = fetch('/_nodes/'+node_encode);
+    stats_d = fetch('/_nodes/'+node_encode+'/stats');
 rescue
     err.puts "Fetch error"
     exit 1


### PR DESCRIPTION
To avoid download of all nodes details. (sorry, didnt test, done via github.com).