### PR TITLE
Uri escape deprecated

### DIFF
--- a/elasticsearch_
+++ b/elasticsearch_
@@ -158,8 +158,8 @@ data = {};
 begin
     node_encode = URI.encode_www_form_component(@node)
     stats = fetch('/_nodes/'+node_encode+'/stats');
-rescue
-    err.puts "Fetch error"
+rescue => error
+    err.puts "Fetch error: #{error}"
     exit 1
 end
 

--- a/elasticsearch_
+++ b/elasticsearch_
@@ -31,7 +31,7 @@ mode = $0.gsub /.*\/elasticsearch_/, ""
 
 if ARGV[0] == "autoconf"
     begin
-        node_encode = URI.escape(@node)
+        node_encode = URI.encode_www_form_component(@node)
         nodes_d = fetch('/_nodes/'+node_encode);
         puts "yes"
         exit 0
@@ -156,7 +156,7 @@ end
 data = {};
 
 begin
-    node_encode = URI.escape(@node)
+    node_encode = URI.encode_www_form_component(@node)
     stats = fetch('/_nodes/'+node_encode+'/stats');
 rescue
     err.puts "Fetch error"


### PR DESCRIPTION
URI.escape has been deprecated for some time and has been removed in ruby 3.0. Use the URI.encode_www_form_component method instead. 

See e.g. https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string for background.

Addresses #12 